### PR TITLE
Force eventmanager refresh when app brought to foreground

### DIFF
--- a/Upcoming/EKEventManager.m
+++ b/Upcoming/EKEventManager.m
@@ -141,13 +141,8 @@ NSString * const EKEventManagerSourcesKeyPath = @"sources";
 }
 
 - (void)loadEvents {
-    [self willChangeValueForKey:EKEventManagerEventsKeyPath];
     [_events removeAllObjects];
-    [self didChangeValueForKey:EKEventManagerEventsKeyPath];
-    
-    [self willChangeValueForKey:EKEventManagerNextEventKeyPath];
     _nextEvent = nil;
-    [self didChangeValueForKey:EKEventManagerNextEventKeyPath];
     
     // Get the appropriate calendar
     NSCalendar *calendar = [NSCalendar currentCalendar];
@@ -171,6 +166,8 @@ NSString * const EKEventManagerSourcesKeyPath = @"sources";
     
     // no calendars selected. Empty views
     if (calendars == nil || [calendars count] == 0) {
+        [self didChangeValueForKey:EKEventManagerEventsKeyPath];
+        [self didChangeValueForKey:EKEventManagerNextEventKeyPath];
         return;
     }
     

--- a/Upcoming/TLAppDelegate.m
+++ b/Upcoming/TLAppDelegate.m
@@ -7,8 +7,8 @@
 //
 
 #import "TLAppDelegate.h"
-
 #import "TLRootViewController.h"
+#import "EKEventManager.h"
 
 #include <sys/types.h>
 #include <sys/sysctl.h>
@@ -26,6 +26,10 @@
     [self setupDevice];
         
     return YES;
+}
+
+- (void)applicationWillEnterForeground:(UIApplication *)application {
+    [[EKEventManager sharedInstance] refresh];
 }
 
 -(void)setupDevice


### PR DESCRIPTION
Also reduced KVO calls for initial / zero event state. Fixes #22 and #23.
