### PR TITLE
Fix building if path contains spaces

### DIFF
--- a/Upcoming.xcodeproj/project.pbxproj
+++ b/Upcoming.xcodeproj/project.pbxproj
@@ -680,7 +680,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Upcoming/Upcoming-Prefix.pch";
 				INFOPLIST_FILE = "Upcoming/Upcoming-Info.plist";
-				LIBRARY_SEARCH_PATHS = "$(PODS_ROOT)/TestFlightSDK";
+				LIBRARY_SEARCH_PATHS = "\"$(PODS_ROOT)/TestFlightSDK\"";
 				PRODUCT_NAME = Upcoming;
 				WRAPPER_EXTENSION = app;
 			};
@@ -694,7 +694,7 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Upcoming/Upcoming-Prefix.pch";
 				INFOPLIST_FILE = "Upcoming/Upcoming-Info.plist";
-				LIBRARY_SEARCH_PATHS = "$(PODS_ROOT)/TestFlightSDK";
+				LIBRARY_SEARCH_PATHS = "\"$(PODS_ROOT)/TestFlightSDK\"";
 				PRODUCT_NAME = Upcoming;
 				PROVISIONING_PROFILE = "";
 				WRAPPER_EXTENSION = app;


### PR DESCRIPTION
Building the project has failed if the project path contained spaces as the linker treated it like two different directories (e.g. `-L/Users/john/GitHub -LRepositories/Upcoming` if the path was `/Users/john/GitHub Repositories/Upcoming`). Enclosing `LIBRARY_SEARCH_PATHS` in quotation marks fixes this.
